### PR TITLE
Refactor Tilda integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,31 +2,39 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
-    tags:
-    - '*'
+    branches: [main]
+    tags: ['*']
+  pull_request:
+    branches: [main]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  test:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.11']
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install django django-object-actions requests
+      - run: pip install .
+      - run: python example_project/manage.py test
 
-    - name: Create sdist
-      run: python setup.py sdist
-
-    - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create sdist
+        run: python setup.py sdist
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['*']
   pull_request:
     branches: [main]
 
@@ -26,13 +25,15 @@ jobs:
       - run: python example_project/manage.py test
 
   publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Create sdist
-        run: python setup.py sdist
+      - run: python -m pip install --upgrade pip
+      - run: pip install build
+      - name: Build package
+        run: python -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-tilda',
-    version='1.0.14',
+    version='1.1.0',
     author='Ivan Lukyanets',
     author_email='lukyanets.ivan@gmail.com',
     url='https://github.com/1vank1n/django-tilda',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 setup(
@@ -7,19 +7,17 @@ setup(
     author='Ivan Lukyanets',
     author_email='lukyanets.ivan@gmail.com',
     url='https://github.com/1vank1n/django-tilda',
-    packages=[
-        'tilda',
-        'tilda.locale',
-    ],
+    packages=find_packages(exclude=("example_project",)),
     include_package_data=True,
     license='MIT',
     description='A Django app for fetch/download pages from API Tilda.cc',
     keywords='django tilda',
     long_description=open('README.rst').read(),
     install_requires=[
-        'django-object-actions==0.10.0',
-        'requests==2.32.2',
+        'django-object-actions>=0.10.0',
+        'requests>=2.32.0',
     ],
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
@@ -27,8 +25,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 )

--- a/tilda/admin.py
+++ b/tilda/admin.py
@@ -1,8 +1,7 @@
 # coding: utf-8
-from django.conf import settings
-from django.contrib import (admin, messages)
+from django.contrib import admin, messages
 from django_object_actions import DjangoObjectActions
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext, gettext_lazy as _
 
 from . import api
 from . import models
@@ -31,30 +30,30 @@ class TildaPageAdmin(DjangoObjectActions, admin.ModelAdmin):
             messages.add_message(
                 request,
                 messages.SUCCESS,
-                _(u'Pages successfuly fetched from Tilda')
+                gettext('Pages successfully fetched from Tilda')
             )
         else:
             messages.add_message(
                 request,
                 messages.ERROR,
-                _(u'Nothing fetched. Perharps wrong settings')
+                gettext('Nothing fetched. Perhaps wrong settings')
             )
-    fetch_pages.label = _(u'Fetch pages')
+    fetch_pages.label = _('Fetch pages')
 
     def synchronize_page(self, request, obj):
         if api.api_getpageexport(obj.id):
             messages.add_message(
                 request,
                 messages.SUCCESS,
-                _(u'Page «{}» successfuly synced from Tilda'.format(obj.title))
+                gettext('Page «%(title)s» successfully synced from Tilda') % {'title': obj.title}
             )
         else:
             messages.add_message(
                 request,
                 messages.ERROR,
-                _(u'Something wrong...')
+                gettext('Something wrong...')
             )
-    synchronize_page.label = _(u'Synchronize')
+    synchronize_page.label = _('Synchronize')
 
     change_actions = ('synchronize_page', )
     changelist_actions = ('fetch_pages', )

--- a/tilda/api.py
+++ b/tilda/api.py
@@ -1,4 +1,6 @@
+import logging
 import os
+
 import requests
 from django.conf import settings
 from django.utils.timezone import now
@@ -7,77 +9,83 @@ from .helpers import download_file, make_unique
 from . import models
 
 
-API_HOST = 'http://api.tildacdn.info/v1'
+logger = logging.getLogger(__name__)
+
+API_HOST = 'https://api.tildacdn.info/v1'
 API_PAYLOAD = {
     'publickey': settings.TILDA_PUBLIC_KEY,
     'secretkey': settings.TILDA_SECRET_KEY
 }
+API_TIMEOUT = getattr(settings, 'TILDA_TIMEOUT', 10)
 
 
 def api_getpageslist():
-    url = '{}/getpageslist'.format(API_HOST)
+    url = f"{API_HOST}/getpageslist"
     payload = API_PAYLOAD.copy()
     payload['projectid'] = settings.TILDA_PROJECTID
-    req = requests.get(url, params=payload, verify=False)
-    if req.status_code == 200:
-        res = req.json()
-        if res['status'] == 'FOUND':
-            for r in res['result']:
-                obj, created = models.TildaPage.objects.get_or_create(
-                    id=r['id']
-                )
+    try:
+        req = requests.get(url, params=payload, timeout=API_TIMEOUT)
+        req.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Error fetching pages list from Tilda: %s", exc)
+        return False
 
-                obj.title = r['title']
-                obj.save()
-            return True
+    res = req.json()
+    if res.get('status') == 'FOUND':
+        for r in res.get('result', []):
+            obj, _created = models.TildaPage.objects.get_or_create(
+                id=r['id']
+            )
+            obj.title = r['title']
+            obj.save()
+        return True
     return False
 
 
 def api_getpageexport(page_id):
-    url = '{}/getpageexport'.format(API_HOST)
+    url = f"{API_HOST}/getpageexport"
     page = models.TildaPage.objects.get(id=page_id)
     payload = API_PAYLOAD.copy()
     payload['pageid'] = page.id
-    req = requests.get(url, params=payload, verify=False)
-    if req.status_code == 200:
-        res = req.json()
-        if res['status'] == 'FOUND':
+    try:
+        req = requests.get(url, params=payload, timeout=API_TIMEOUT)
+        req.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Error fetching page export from Tilda: %s", exc)
+        return False
 
-            """
-                Remove old images
-            """
+    res = req.json()
+    if res.get('status') != 'FOUND':
+        return False
 
-            for img in page._path_images_list():
-                if os.path.exists(img):
-                    os.remove(img)
+    # Remove old images
+    for img in page._path_images_list():
+        if os.path.exists(img):
+            os.remove(img)
 
-            """
-                Download new images, css, js
-            """
+    # Download new images, css, js
+    result = res['result']
+    page.title = result['title']
+    page.html = result['html']
+    page.images = result['images']
+    page.css = result['css']
+    page.js = result['js']
+    page.synchronized = now()
+    page.save()
 
-            result = res['result']
-            page.title = result['title']
-            page.html = result['html']
-            page.images = result['images']
-            page.css = result['css']
-            page.js = result['js']
-            page.synchronized = now()
-            page.save()
+    for r in make_unique(result['images']):
+        filename = os.path.join(settings.TILDA_MEDIA_IMAGES, r['to'])
+        if download_file(r['from'], filename):
+            url = os.path.join(settings.TILDA_MEDIA_IMAGES_URL, r['to'])
+            page.html = page.html.replace(r['to'], url)
+    page.save()
 
-            for r in make_unique(result['images']):
-                filename = os.path.join(settings.TILDA_MEDIA_IMAGES, r['to'])
-                download_file(r['from'], filename)
-                url = os.path.join(settings.TILDA_MEDIA_IMAGES_URL, r['to'])
-                page.html = page.html.replace(r['to'], url)
-            page.save()
+    for r in make_unique(result['css']):
+        filename = os.path.join(settings.TILDA_MEDIA_CSS, r['to'])
+        download_file(r['from'], filename)
 
-            for r in make_unique(result['css']):
-                filename = os.path.join(settings.TILDA_MEDIA_CSS, r['to'])
-                download_file(r['from'], filename)
+    for r in make_unique(result['js']):
+        filename = os.path.join(settings.TILDA_MEDIA_JS, r['to'])
+        download_file(r['from'], filename)
 
-            for r in make_unique(result['js']):
-                filename = os.path.join(settings.TILDA_MEDIA_JS, r['to'])
-                download_file(r['from'], filename)
-
-            return True
-    return False
+    return True

--- a/tilda/fields.py
+++ b/tilda/fields.py
@@ -1,29 +1,35 @@
 from django import forms
+from django.apps import apps
 from django.conf import settings
 from django.db import models
 from django.template.loader import render_to_string
-from django.apps import apps
 
 
 class TildaWidget(forms.Widget):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
+        attrs = attrs or {}
+        attrs.setdefault('id', f'id_{name}')
         is_required = self.is_required
-
-        if not hasattr(settings, 'TILDA_PUBLIC_KEY') or \
-           not hasattr(settings, 'TILDA_SECRET_KEY') or \
-           not hasattr(settings, 'TILDA_PROJECTID') or \
-           not settings.TILDA_PUBLIC_KEY or \
-           not settings.TILDA_SECRET_KEY or \
-           not settings.TILDA_PROJECTID:
-            is_need_config = True
+        is_need_config = any(
+            not getattr(settings, attr, None)
+            for attr in ['TILDA_PUBLIC_KEY', 'TILDA_SECRET_KEY', 'TILDA_PROJECTID']
+        )
 
         TildaPage = apps.get_model('tilda', 'TildaPage')
         queryset = TildaPage.objects.all()
+        obj = queryset.filter(id=value).first() if queryset and value else None
 
-        if queryset and value:
-            obj = queryset.filter(id=value)[0]
-        return render_to_string('tilda/widget.html', locals())
+        context = {
+            'is_required': is_required,
+            'is_need_config': is_need_config,
+            'queryset': queryset,
+            'name': name,
+            'value': value,
+            'attrs': attrs,
+            'obj': obj,
+        }
+        return render_to_string('tilda/widget.html', context)
 
 
 class TildaPageField(models.ForeignKey):

--- a/tilda/helpers.py
+++ b/tilda/helpers.py
@@ -1,12 +1,24 @@
+import logging
 import requests
+
+logger = logging.getLogger(__name__)
+TIMEOUT = 10
 
 
 def download_file(url, filename):
-    headers = {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0'}
-    r = requests.get(url, stream=True, verify=False, headers=headers)
-    with open(filename, 'wb') as fd:
-        for chunk in r.iter_content(chunk_size=128):
-            fd.write(chunk)
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0'
+    }
+    try:
+        with requests.get(url, stream=True, timeout=TIMEOUT, headers=headers) as r:
+            r.raise_for_status()
+            with open(filename, 'wb') as fd:
+                for chunk in r.iter_content(chunk_size=128):
+                    fd.write(chunk)
+        return True
+    except requests.RequestException as exc:
+        logger.error("Failed to download %s: %s", url, exc)
+        return False
 
 
 def make_unique(original_list):

--- a/tilda/migrations/0002_jsonfields.py
+++ b/tilda/migrations/0002_jsonfields.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tilda', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='tildapage',
+            name='images',
+            field=models.JSONField(blank=True, default=list, verbose_name='Images'),
+        ),
+        migrations.AlterField(
+            model_name='tildapage',
+            name='css',
+            field=models.JSONField(blank=True, default=list, verbose_name='CSS'),
+        ),
+        migrations.AlterField(
+            model_name='tildapage',
+            name='js',
+            field=models.JSONField(blank=True, default=list, verbose_name='JS'),
+        ),
+    ]

--- a/tilda/models.py
+++ b/tilda/models.py
@@ -24,19 +24,22 @@ class TildaPage(models.Model):
         blank=True
     )
 
-    images = models.TextField(
+    images = models.JSONField(
         _(u'Images'),
-        blank=True
+        default=list,
+        blank=True,
     )
 
-    css = models.TextField(
+    css = models.JSONField(
         _(u'CSS'),
-        blank=True
+        default=list,
+        blank=True,
     )
 
-    js = models.TextField(
+    js = models.JSONField(
         _(u'JS'),
-        blank=True
+        default=list,
+        blank=True,
     )
 
     synchronized = models.DateTimeField(
@@ -59,7 +62,7 @@ class TildaPage(models.Model):
         if self.images:
             return [
                 os.path.join('/media/tilda/images', r['to'])
-                for r in eval(self.images)
+                for r in self.images
             ]
         return []
 
@@ -67,7 +70,7 @@ class TildaPage(models.Model):
         if self.css:
             return [
                 os.path.join('/media/tilda/css', r['to'])
-                for r in eval(self.css)
+                for r in self.css
             ]
         return []
 
@@ -75,7 +78,7 @@ class TildaPage(models.Model):
         if self.js:
             return [
                 os.path.join('/media/tilda/js', r['to'])
-                for r in eval(self.js)
+                for r in self.js
             ]
         return []
 
@@ -83,7 +86,7 @@ class TildaPage(models.Model):
         if self.images:
             return [
                 os.path.join(settings.TILDA_MEDIA_IMAGES, r['to'])
-                for r in eval(self.images)
+                for r in self.images
             ]
         return []
 
@@ -91,7 +94,7 @@ class TildaPage(models.Model):
         if self.css:
             return [
                 os.path.join(settings.TILDA_MEDIA_CSS, r['to'])
-                for r in eval(self.css)
+                for r in self.css
             ]
         return []
 
@@ -99,12 +102,9 @@ class TildaPage(models.Model):
         if self.js:
             return [
                 os.path.join(settings.TILDA_MEDIA_JS, r['to'])
-                for r in eval(self.js)
+                for r in self.js
             ]
         return []
-
-    def __unicode__(self):
-        return self.title
 
     def __str__(self):
         return self.title

--- a/tilda/templates/tilda/widget.html
+++ b/tilda/templates/tilda/widget.html
@@ -6,13 +6,13 @@
 		{% trans "Insert TILDA_PUBLIC_KEY, TILDA_SECRET_KEY, TILDA_PROJECTID in settings.py" %}
 	</div>
 {% else %}
-	<div>
-		<select type="text" name="{{ name }}" id="{{ attrs.id }}"/>
-			<option value="">---</option>
-			{% for q in queryset %}
-				<option value="{{ q.id }}" {% if q.id == value %}selected{% endif %}>{{ q.title }}</option>
-			{% endfor %}
-		</select>
+        <div>
+                <select name="{{ name }}" id="{{ attrs.id }}">
+                        <option value="">---</option>
+                        {% for q in queryset %}
+                                <option value="{{ q.id }}" {% if q.id == value %}selected{% endif %}>{{ q.title }}</option>
+                        {% endfor %}
+                </select>
 
 		<a style="margin-left:10px;" data-js="tildaPagesFetch" href="javascript:void(0);">{% trans "Fetch list of pages from tilda.cc" %}</a>
 	</div>

--- a/tilda/tests/test_models.py
+++ b/tilda/tests/test_models.py
@@ -1,0 +1,29 @@
+import os
+
+from django.test import TestCase
+
+from tilda.models import TildaPage
+
+
+class TildaPageModelTests(TestCase):
+    def test_lists_from_json_fields(self):
+        page = TildaPage.objects.create(
+            id='1',
+            title='Page',
+            images=[{'to': 'img.jpg'}],
+            css=[{'to': 'style.css'}],
+            js=[{'to': 'app.js'}],
+        )
+
+        self.assertEqual(
+            page.get_images_list(),
+            [os.path.join('/media/tilda/images', 'img.jpg')],
+        )
+        self.assertEqual(
+            page.get_css_list(),
+            [os.path.join('/media/tilda/css', 'style.css')],
+        )
+        self.assertEqual(
+            page.get_js_list(),
+            [os.path.join('/media/tilda/js', 'app.js')],
+        )


### PR DESCRIPTION
## Summary
- Secure API calls and resource downloads
- Use JSONField for page assets
- Modernize widget, admin, packaging and CI

## Testing
- `python example_project/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6895d309b2d8833287b33c1809efdd48